### PR TITLE
get rid of magic string in location/host key, fix format per local pref

### DIFF
--- a/lambda/action_network.py
+++ b/lambda/action_network.py
@@ -5,6 +5,8 @@ from typing import Dict
 import requests
 from dateutil import parser
 
+from common import make_key
+
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
@@ -91,12 +93,6 @@ def get_events_from_events_campaign(return_events=None,
     return return_events
 
 
-def make_key(properties: Dict) -> str:
-    return '{location}::{host}'.format(
-        location=properties.get('location', ''),
-        host=properties.get('host', ''))
-
-
 def convert_event(event: Dict) -> Dict:
     contact_name = get_contact_name(event)
     #yapf:disable
@@ -117,9 +113,6 @@ def convert_event(event: Dict) -> Dict:
     }
     #yapf:enable
     return {
-        # special handling for key for actionnetwork events allows
-        # for more than one event per locaion
-        # make_key builds a compound key of <location>::<host>
         make_key(properties): {
             'properties': properties,
         }

--- a/lambda/common.py
+++ b/lambda/common.py
@@ -1,0 +1,11 @@
+from typing import Dict
+from collections import namedtuple
+
+LocationHostKey = namedtuple('LocationHostKey', ['location', 'host'])
+
+
+def make_key(properties: Dict) -> LocationHostKey:
+    return LocationHostKey(
+        properties.get('location') or '',
+        properties.get('host', '')
+    )

--- a/lambda/marchon.py
+++ b/lambda/marchon.py
@@ -3,6 +3,7 @@ import io
 import json
 import logging
 import os
+import re
 import traceback
 from typing import Dict
 
@@ -117,7 +118,7 @@ def get_geodata(sheet, keys, countries=None):
     for key in keys:
         # San Jose, CA doesn't return results
         response = geocoder.forward(
-            key.location.replace(', CA', ', California'),
+            re.sub(r', CA$', ', California', key.location),
             limit=1,
             country=countries).geojson()
         if 'features' in response and response['features']:

--- a/lambda/marchon.py
+++ b/lambda/marchon.py
@@ -12,7 +12,8 @@ from apiclient.discovery import build
 from mapbox import Geocoder
 from PIL import Image
 
-from action_network import get_events_from_events_campaign, make_key
+from action_network import get_events_from_events_campaign
+from common import make_key
 
 logging.basicConfig(level=logging.DEBUG, format='%(levelname)s %(message)s')
 log = logging.getLogger(__name__)
@@ -49,7 +50,7 @@ def read_sheet(sheet_range, fields, location_idx, affiliate):
                     props[field] = False
         # skip if no location; nothing to map
         if row[location_idx]:
-            rows[row[location_idx].strip()] = {'properties': props}
+            rows[make_key(props)] = {'properties': props}
             log.debug('row %s\t%s\t%s',
                       len(rows) + 1, props['name'], props['location'])
         else:
@@ -65,9 +66,11 @@ def get_event_data():
     9 Twitter 10 Insta
     '''
     # keep these fields
+    #yapf:disable
     fields = {'name': 0, 'eventDate': 1, 'eventLink': 2, 'location': 3, 'host': 4,
               'affiliate': 5, 'contactName': 6, 'contactEmail': 7, 'facebook': 8,
               'twitter': 9, 'instagram': 10, 'motpLink': 12}
+    #yapf:enable
     sheet = read_sheet('Sheet1!A1:M', fields, 3, False)
 
     # add default name
@@ -86,22 +89,12 @@ def get_sheet_data():
      16 Event Link, 17 Photo, 18 About
     '''
     # keep these fields
-    fields = {
-        'name': 0,
-        'location': 1,
-        'contactName': 3,
-        'contactEmail': 5,
-        'facebook': 9,
-        'twitter': 10,
-        'instagram': 11,
-        'other': 12,
-        'website': 13,
-        'event': 14,
-        'eventDate': 15,
-        'eventLink': 16,
-        'photo': 17,
-        'about': 18
-    }
+    #yapf:disable
+    fields = { 'name': 0, 'location': 1, 'contactName': 3, 'contactEmail': 5,
+               'facebook': 9, 'twitter': 10, 'instagram': 11, 'other': 12,
+               'website': 13, 'event': 14, 'eventDate': 15, 'eventLink': 16,
+               'photo': 17, 'about': 18 }
+    #yapf:enable
     return read_sheet('Sheet1!A1:S', fields, 1, True)
 
 
@@ -110,21 +103,10 @@ def get_geojson(url):
     resp = requests.get('https://s3.amazonaws.com/ragtag-marchon/%s' % url)
     features = {}
     for feature in resp.json()['features']:
-        # special handling for key for actionnetwork events allows
-        # for more than one event per locaion
-        # make_key builds a compound key of <location>::<host>
-        if feature['properties'].get('source', '') == 'actionnetwork':
-            key = make_key(feature['properties'])
-        else:
-            key = feature['properties']['location']
+        key = make_key(feature['properties'])
         features[key] = feature
     log.info('read %s features', len(features))
     return features
-
-
-def get_location_from_key(key: str) -> str:
-    parts = key.split('::', 1)
-    return parts[0]
 
 
 def get_geodata(sheet, keys, countries=None):
@@ -135,10 +117,7 @@ def get_geodata(sheet, keys, countries=None):
     for key in keys:
         # San Jose, CA doesn't return results
         response = geocoder.forward(
-            # special handling for key for actionnetwork events allows
-            # for more than one event per locaion
-            # make_key builds a compound key of <location>::<host>
-            get_location_from_key(key).replace(', CA', ', California'),
+            key.location.replace(', CA', ', California'),
             limit=1,
             country=countries).geojson()
         if 'features' in response and response['features']:

--- a/lambda/test_action_network.py
+++ b/lambda/test_action_network.py
@@ -4,6 +4,7 @@ from action_network import (convert_event, get_email_address_from_organizer,
                             get_events_from_events_campaign, get_organizer,
                             make_location)
 from action_network_sample_data import make_test_event, make_test_location
+from common import LocationHostKey
 
 
 def test_make_location_everything():
@@ -104,8 +105,9 @@ def test_get_email_address():
 
 def test_convert_event():
     x = convert_event(make_test_event())
-    assert '10025::Larry Person' in x
-    converted_event = x['10025::Larry Person']
+    lhk = LocationHostKey('10025', 'Larry Person')
+    assert lhk in x
+    converted_event = x[lhk]
     assert 'properties' in converted_event
     p = converted_event['properties']
     assert p['source'] == 'actionnetwork'

--- a/lambda/test_events.py
+++ b/lambda/test_events.py
@@ -2,6 +2,7 @@ import json
 
 import requests_mock
 
+from common import LocationHostKey
 import marchon
 '''
     set these in environment
@@ -16,8 +17,7 @@ def test_get_geojson():
     def response_callback(_, context):
         #yapf:disable
         features = {
-            'type':
-            'FeatureCollection',
+            'type': 'FeatureCollection',
             'features': [{
                 'properties': {
                     'source': 'events',
@@ -45,17 +45,8 @@ def test_get_geojson():
             text=response_callback)
         x = marchon.get_geojson('events.json')
         assert len(x) == 2
-        assert 'New Paltz, NY' in x
-        assert 'Des Moines, IA 50312::Mark Langgin' in x
-
-
-def test_get_location_from_key():
-    x = marchon.get_location_from_key('New York, NY 10025::Larry Person')
-    assert x == 'New York, NY 10025'
-    x = marchon.get_location_from_key('New York, NY 10025:Larry Person')
-    assert x == 'New York, NY 10025:Larry Person'
-    x = marchon.get_location_from_key('New York, NY 10025')
-    assert x == 'New York, NY 10025'
+        assert LocationHostKey('New Paltz, NY', 'March On Hudson Valley') in x
+        assert LocationHostKey('Des Moines, IA 50312', 'Mark Langgin') in x
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. Code improvement to make location key more readable and less exceptional.
2. Closes #17 