### PR TITLE
better handling of past events - issue11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .cache/**
+testdata.json

--- a/map.js
+++ b/map.js
@@ -68,20 +68,20 @@ const app = new Vue({
       // Mapbox won't share if it loads the data: https://github.com/mapbox/mapbox-gl-js/issues/1762
       // TODO: IE11
       geojson.then(function(data) {
+        _this.features = data.features;
         const affiliateTrue = {
           type: 'FeatureCollection',
-          features: _.filter(data.features, function(feature) { return feature.properties.source === 'events' && feature.properties.affiliate; }),
+          features: _.filter(_this.futureFeatures, function(feature) { return feature.properties.source === 'events' && feature.properties.affiliate; }),
         };
         const affiliateFalse = {
           type: 'FeatureCollection',
-          features: _.filter(data.features, function(feature) { return feature.properties.source === 'events' && !feature.properties.affiliate; }),
+          features: _.filter(_this.futureFeatures, function(feature) { return feature.properties.source === 'events' && !feature.properties.affiliate; }),
         };
         const sourceActionnetwork = {
           type: 'FeatureCollection',
-          features: _.filter(data.features, function(feature) { return feature.properties.source === 'actionnetwork'; }),
+          features: _.filter(_this.futureFeatures, function(feature) { return feature.properties.source === 'actionnetwork'; }),
         };
 
-        _this.features = data.features;
         if (document.getElementById('affiliate')) {
           document.getElementById('affiliate').style.display = 'block';
         }
@@ -121,9 +121,12 @@ const app = new Vue({
   },
 
   computed: {
-    events: function events() {
-      const now = moment();
-      const ev = this.features.map(function(feature) {
+    // the features that are in the future or the recent past (the ones we display).
+    // this is where we filter out the old stuff that doesn't show up anywhere on the
+    // map.
+    futureFeatures: function futureFeatures() {
+      const now = moment().subtract(3, 'days'); // recently passed dates are still 'current'
+      const ff = this.features.map(function(feature) {
         const props = feature.properties;
 
         if (!props.eventDate) {
@@ -135,6 +138,18 @@ const app = new Vue({
           return null;
         }
 
+        return feature;
+      });
+      return _.compact(ff);
+    },
+    // the events. This is a processed version of the futureFeatures, displayed on the
+    // popup.
+    events: function events() {
+      return this.futureFeatures.map(function(feature) {
+        const props = feature.properties;
+
+        const dt = moment(feature.properties.eventDate, 'MM/DD/YYYY');
+
         return {
           location: props.location,
           name: props.event,
@@ -142,12 +157,9 @@ const app = new Vue({
           weekday: dt.format('dddd'),
           month: dt.format('MMMM'),
           day: dt.format('D'),
-          past: dt.isBefore(now),
           link: props.eventLink,
         };
       });
-
-      return _.compact(ev);
     },
 
     sortedUpcomingEvents: function sortedEvents() {
@@ -286,7 +298,7 @@ const app = new Vue({
       props.mailto = 'mailto:' + props.contactEmail;
       if (props.eventDate) {
         props.eventMeta = _.find(this.events, function(ev) {
-          return ev.location === props.location && !ev.past;
+          return ev.location === props.location;
         });
       }
       this.activeGroup = props;


### PR DESCRIPTION
Filter out entirely the really old ones, and don't die on the other past events.

Executive decision that we display events from up to 3 days ago.

New `futureFeatures` computed property that has the features filtered to remove the ones that are too old.

We might want to do something to distinguish the events that are 2 days old from the ones that are actually in the future, but this is at least better than where we were with the javascript error.