### PR TITLE
Fix legend per March On spec, allow "No" in "Affiliates" column, only show mailto if email exists

### DIFF
--- a/events.html
+++ b/events.html
@@ -78,7 +78,7 @@
       <div class="map-widget filter-widget">
         <template v-for="layer in layers">
           <div>
-            <label for="layer.layerId"><img :src="'assets/'+layer.icon">{{layer.label}}</label>
+            <label v-if="layer.labelVisible == true" for="layer.layerId"><img :src="'assets/'+layer.icon">{{layer.label}}</label>
           </div>
         </template>
       </div>

--- a/events.html
+++ b/events.html
@@ -75,16 +75,9 @@
       <i class="fa fa-circle"></i>
     </div>
     <script type="text/x-template" id="layerfilter-template">
-      <div class="map-widget filter-widget" style="display:none!important;">
+      <div class="map-widget filter-widget">
         <template v-for="layer in layers">
           <div>
-            <input
-              type="checkbox"
-              :value="layer.layerId"
-              :id="layer.layerId"
-              v-model="checkedLayers"
-              @change="showHideLayers()"
-            >
             <label for="layer.layerId"><img :src="'assets/'+layer.icon">{{layer.label}}</label>
           </div>
         </template>

--- a/map.css
+++ b/map.css
@@ -155,6 +155,10 @@ nice to get that cleaned up. - Marion Newlevant */
   bottom: 2px;
 }
 
+.filter-widget label {
+  margin-bottom: 0px;
+}
+
 /* inspired by https://www.sitepoint.com/create-calendar-icon-html5-css3/ */
 time.icon
 {

--- a/map.js
+++ b/map.js
@@ -84,9 +84,11 @@ const app = new Vue({
 
 	//@RobinColodzin 12.9.2018 - If we are on the events page, only use the pink star
 	var isEventsPage = false;
+	/*
 	if (typeof document.body.classList != "undefined" && document.body.classList.length > 0 && document.body.classList.contains("events")) {
 		isEventsPage = true;
 	}
+	*/
 
     this.map = new mapboxgl.Map({
       container: 'map',
@@ -194,7 +196,8 @@ const app = new Vue({
           });
         }
         if (affiliateTrue.features.length) {
-		  var icon = (isEventsPage ? defaultIcon : 'smallstar');
+  		  //var icon = (isEventsPage ? defaultIcon : 'smallstar');
+		  var icon = 'smallstar';
 		  var iconImg = icon + ".svg";
           _this.map.addSource('marchon-affiliate-true-geojson', { type: 'geojson', data: affiliateTrue });
           _this.addLayer('marchon-affiliate-true', 'marchon-affiliate-true-geojson', { 'icon-image': icon });

--- a/map.js
+++ b/map.js
@@ -130,11 +130,11 @@ const app = new Vue({
         // sort out our features into what will be our map layers
         const affiliateTrue = {
           type: 'FeatureCollection',
-          features: _.filter(features, function(feature) { return feature.properties.source === 'events' && feature.properties.affiliate; }),
+          features: _.filter(features, function(feature) { return feature.properties.source === 'events' && feature.properties.affiliate && feature.properties.affiliate != "No"; }),
         };
         const affiliateFalse = {
           type: 'FeatureCollection',
-          features: _.filter(features, function(feature) { return feature.properties.source === 'events' && !feature.properties.affiliate; }),
+          features: _.filter(features, function(feature) { return feature.properties.source === 'events' && (!feature.properties.affiliate || feature.properties.affiliate === "No"); }),
         };
         // familySepEvents: June 30 2018
         const familySepEventsFuture = {
@@ -193,6 +193,7 @@ const app = new Vue({
             label: 'Non Affiliates',
             icon: iconImg,
             initiallyChecked: true,
+            labelVisible: false,
           });
         }
         if (affiliateTrue.features.length) {
@@ -203,9 +204,10 @@ const app = new Vue({
           _this.addLayer('marchon-affiliate-true', 'marchon-affiliate-true-geojson', { 'icon-image': icon });
           _this.mapLayers.push({
             layerId: 'marchon-affiliate-true',
-            label: 'Affiliates',
+            label: 'March On Affiliates',
             icon: iconImg,
             initiallyChecked: true,
+            labelVisible: true,
           });
         }
         // familySepEvents
@@ -458,7 +460,9 @@ const app = new Vue({
     showFeature: function showFeature(feature) {
       const props = feature.properties;
 
-      props.mailto = 'mailto:' + props.contactEmail;
+      if (props.contactEmail) {
+        props.mailto = 'mailto:' + props.contactEmail;
+      }
       if (props.eventDate) {
         props.eventMeta = _.find(this.events, function(ev) {
           return ev.location === props.location;


### PR DESCRIPTION
Updated for Mach On's latest requests:
- Restore the two different star colors for Affiliates and Non-affiliates
- Restore the legend, but don't allow toggles, and only say "Affiliates"
- Allow March On to put "No" in the Affiliates column in the spreadsheet
- Don't display email icon on overly if email doesn't exist

(@rcolodzin , your commits all look good to me, so if mine looks good to you, we can get this merged)